### PR TITLE
ci: fix M11.C managed workflow handle-source path

### DIFF
--- a/.github/workflows/dev_full_m11_c_managed.yml
+++ b/.github/workflows/dev_full_m11_c_managed.yml
@@ -103,7 +103,6 @@ jobs:
           import hashlib
           import json
           import os
-          import re
           from datetime import datetime, timezone
           from pathlib import Path
           from typing import Any
@@ -112,7 +111,6 @@ jobs:
           from botocore.exceptions import BotoCoreError, ClientError
 
 
-          HANDLES_PATH = Path("docs/model_spec/platform/migration_to_dev/dev_full_handles.registry.v0.md")
           REQUIRED_HANDLES = [
               "S3_EVIDENCE_BUCKET",
               "S3_RUN_CONTROL_ROOT_PATTERN",
@@ -129,26 +127,6 @@ jobs:
 
           def now_utc() -> str:
               return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-          def parse_handles(path: Path) -> dict[str, Any]:
-              out: dict[str, Any] = {}
-              rx = re.compile(r"^\* `([^`=]+?)\s*=\s*([^`]+)`")
-              for line in path.read_text(encoding="utf-8").splitlines():
-                  m = rx.match(line.strip())
-                  if not m:
-                      continue
-                  key = m.group(1).strip()
-                  raw = m.group(2).strip()
-                  if raw.startswith('"') and raw.endswith('"'):
-                      out[key] = raw[1:-1]
-                  elif raw.lower() == "true":
-                      out[key] = True
-                  elif raw.lower() == "false":
-                      out[key] = False
-                  else:
-                      out[key] = raw
-              return out
 
 
           def is_placeholder(value: Any) -> bool:
@@ -241,45 +219,11 @@ jobs:
 
           s3 = boto3.client("s3", region_name=region)
 
-          handle_values: dict[str, Any] = {}
-          try:
-              handle_values = parse_handles(HANDLES_PATH)
-          except Exception as exc:  # noqa: BLE001
-              push_blocker(blockers, f"Handle registry unreadable: {type(exc).__name__}", str(HANDLES_PATH))
-
-          for key in REQUIRED_HANDLES:
-              if key not in handle_values:
-                  status = "missing"
-                  value_out = ""
-                  unresolved_handles.append(key)
-              else:
-                  value = handle_values.get(key)
-                  value_out = str(value)
-                  if is_placeholder(value):
-                      status = "placeholder"
-                      unresolved_handles.append(key)
-                  elif is_wildcard(value):
-                      status = "wildcard"
-                      unresolved_handles.append(key)
-                  else:
-                      status = "resolved"
-              handle_rows.append({"handle": key, "status": status, "value": value_out})
-
-          if unresolved_handles:
-              push_blocker(blockers, "One or more required M11.C handles are unresolved.", "handle_registry")
-
-          handle_bucket = str(handle_values.get("S3_EVIDENCE_BUCKET", "")).strip()
-          if handle_bucket and not is_placeholder(handle_bucket) and handle_bucket != evidence_bucket:
-              push_blocker(
-                  blockers,
-                  "Dispatch evidence bucket does not match S3_EVIDENCE_BUCKET handle.",
-                  "S3_EVIDENCE_BUCKET",
-              )
-
           m11b_summary_key = f"evidence/dev_full/run_control/{upstream_m11b}/m11b_execution_summary.json"
 
           m11b_summary: dict[str, Any] = {}
           m11a_summary: dict[str, Any] = {}
+          m11a_snapshot: dict[str, Any] = {}
           m11_handoff: dict[str, Any] = {}
           required_ref_payloads: dict[str, dict[str, Any]] = {}
 
@@ -324,6 +268,60 @@ jobs:
                       push_blocker(blockers, "platform_run_id mismatch between M11.B and M11.A.", m11a_summary_key)
                   if scenario_run_id and str(m11a_summary.get("scenario_run_id", "")).strip() != scenario_run_id:
                       push_blocker(blockers, "scenario_run_id mismatch between M11.B and M11.A.", m11a_summary_key)
+
+                  m11a_snapshot_key = str(
+                      m11a_summary.get("artifact_keys", {}).get("m11a_handle_closure_snapshot", "")
+                  ).strip()
+                  if not m11a_snapshot_key:
+                      push_blocker(blockers, "M11.A handle closure snapshot key missing.", m11a_summary_key)
+                  else:
+                      try:
+                          m11a_snapshot = s3_get_json(s3, evidence_bucket, m11a_snapshot_key)
+                      except (BotoCoreError, ClientError, ValueError, json.JSONDecodeError) as exc:
+                          read_errors.append({"surface": m11a_snapshot_key, "error": type(exc).__name__})
+                          push_blocker(blockers, "M11.A handle closure snapshot unreadable.", m11a_snapshot_key)
+
+          handle_rows_map: dict[str, dict[str, Any]] = {}
+          if m11a_snapshot:
+              rows = m11a_snapshot.get("handle_matrix", [])
+              if not isinstance(rows, list):
+                  push_blocker(blockers, "M11.A handle_matrix is not a list.", "m11a_handle_closure_snapshot")
+                  rows = []
+              for row in rows:
+                  if not isinstance(row, dict):
+                      continue
+                  name = str(row.get("handle", "")).strip()
+                  if not name:
+                      continue
+                  handle_rows_map[name] = row
+
+          for key in REQUIRED_HANDLES:
+              row = handle_rows_map.get(key)
+              if row is None:
+                  status = "missing"
+                  value_out = ""
+                  unresolved_handles.append(key)
+              else:
+                  status = str(row.get("status", "")).strip() or "missing"
+                  value_out = str(row.get("value", ""))
+                  if status != "resolved" or is_placeholder(value_out) or is_wildcard(value_out):
+                      unresolved_handles.append(key)
+              handle_rows.append({"handle": key, "status": status, "value": value_out})
+
+          if unresolved_handles:
+              push_blocker(blockers, "One or more required M11.C handles are unresolved in M11.A snapshot.", "m11a_handle_closure_snapshot")
+
+          handle_bucket = ""
+          for row in handle_rows:
+              if row.get("handle") == "S3_EVIDENCE_BUCKET":
+                  handle_bucket = str(row.get("value", "")).strip()
+                  break
+          if handle_bucket and not is_placeholder(handle_bucket) and handle_bucket != evidence_bucket:
+              push_blocker(
+                  blockers,
+                  "Dispatch evidence bucket does not match S3_EVIDENCE_BUCKET from M11.A snapshot.",
+                  "S3_EVIDENCE_BUCKET",
+              )
 
           m10i_execution = str(m11a_summary.get("upstream_refs", {}).get("m10i_execution_id", "")).strip() if m11a_summary else ""
           if not m10i_execution:


### PR DESCRIPTION
## Summary
- update dev_full_m11_c_managed.yml to source required handle checks from upstream M11.A snapshot
- remove direct dependency on repo-local handle registry file during managed run

## Why
- current M11.C run fails on main because handle registry markdown is not present there
- M11.A already emits authoritative handle closure matrix; M11.C should consume that immutable upstream evidence

## Scope Guard
- workflow-only change