### PR TITLE
ci: pin M11 managed workflow to SageMaker v2 API

### DIFF
--- a/.github/workflows/dev_full_m11_managed.yml
+++ b/.github/workflows/dev_full_m11_managed.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install boto3 botocore sagemaker
+          python -m pip install boto3 botocore "sagemaker<3"
 
       - name: Compute execution metadata
         id: run_meta
@@ -137,7 +137,7 @@ jobs:
           from pathlib import Path
           import boto3
           from botocore.exceptions import ClientError, BotoCoreError
-          from sagemaker.image_uris import retrieve as sm_image_uri
+          from sagemaker import image_uris
 
           def now():
               return datetime.now(timezone.utc).isoformat().replace('+00:00','Z')
@@ -252,7 +252,7 @@ jobs:
               putj(s3,bkt,kl,{'labels':labels,'platform_run_id':pr,'scenario_run_id':sr,'execution_id':exec_id})
               inp={'train_key':ktr,'validation_key':kva,'test_features_key':kte,'test_labels_key':kl}
 
-              image=sm_image_uri(framework='xgboost',region=region,version='1.7-1',image_scope='training',instance_type='ml.m5.large')
+              image=image_uris.retrieve(framework='xgboost',region=region,version='1.7-1',image_scope='training',instance_type='ml.m5.large')
               suf=hashlib.sha256(f'{exec_id}|{fps}'.encode()).hexdigest()[:10]
               tjob=job(f'{train_prefix}-{suf}'); xjob=job(f'{batch_prefix}-{suf}'); model=job(f'{train_prefix}-model-{suf}')
               tr_uri=f"s3://{bkt}/{ktr.rsplit('/',1)[0]}/"


### PR DESCRIPTION
## Summary
- pin M11 managed workflow runtime dependency to sagemaker<3
- restore compatible image URI helper import path for v2 API

## Scope
- .github/workflows/dev_full_m11_managed.yml only

## Why
Run 22460024603 failed with ModuleNotFoundError: No module named 'sagemaker.image_uris' due SageMaker 3.x API drift.