### PR TITLE
ci: add m12a execution mode to managed workflow

### DIFF
--- a/.github/workflows/dev_full_m12_managed.yml
+++ b/.github/workflows/dev_full_m12_managed.yml
@@ -40,6 +40,7 @@ on:
         type: choice
         options:
           - materialization_check
+          - m12a_execute
       upstream_m11j_execution:
         description: Upstream M11.J execution id (entry readiness ref)
         required: true
@@ -78,8 +79,12 @@ jobs:
               exit 1
               ;;
           esac
-          if [[ "${{ inputs.execution_mode }}" != "materialization_check" ]]; then
+          if [[ "${{ inputs.execution_mode }}" != "materialization_check" && "${{ inputs.execution_mode }}" != "m12a_execute" ]]; then
             echo "Unsupported execution_mode='${{ inputs.execution_mode }}'"
+            exit 1
+          fi
+          if [[ "${{ inputs.execution_mode }}" == "m12a_execute" && "${{ inputs.m12_subphase }}" != "A" ]]; then
+            echo "execution_mode='m12a_execute' currently supports only m12_subphase='A'."
             exit 1
           fi
 
@@ -332,6 +337,240 @@ jobs:
                   {
                       "execution_id": exec_id,
                       "requested_subphase": subphase,
+                      "overall_pass": overall_pass,
+                      "blocker_count": len(blockers),
+                      "next_gate": next_gate,
+                      "verdict": verdict,
+                      "evidence_prefix": f"s3://{bucket}/{run_control_prefix}",
+                  },
+                  indent=2,
+                  ensure_ascii=True,
+              )
+          )
+          if not overall_pass:
+              raise SystemExit(1)
+          PY
+
+      - name: Execute M12.A handle closure (managed)
+        if: ${{ inputs.execution_mode == 'm12a_execute' && inputs.m12_subphase == 'A' }}
+        shell: bash
+        env:
+          EXEC_ID: ${{ steps.run_meta.outputs.execution_id }}
+          RUN_DIR: ${{ steps.run_meta.outputs.run_dir }}
+          EVIDENCE_BUCKET: ${{ inputs.evidence_bucket }}
+          AWS_REGION: ${{ inputs.aws_region }}
+          UPSTREAM_M11J_EXEC: ${{ inputs.upstream_m11j_execution }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+          import json
+          import os
+          import re
+          from datetime import datetime, timezone
+          from pathlib import Path
+          from typing import Any
+
+          import boto3
+          from botocore.exceptions import BotoCoreError, ClientError
+
+          def now() -> str:
+              return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+          def s3_get_json(s3: Any, bucket: str, key: str) -> dict[str, Any]:
+              raw = s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+              payload = json.loads(raw)
+              if not isinstance(payload, dict):
+                  raise ValueError("json_not_object")
+              return payload
+
+          def s3_put_json(s3: Any, bucket: str, key: str, payload: dict[str, Any]) -> None:
+              body = (json.dumps(payload, indent=2, ensure_ascii=True) + "\n").encode("utf-8")
+              s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+              s3.head_object(Bucket=bucket, Key=key)
+
+          def dedupe(blockers: list[dict[str, str]]) -> list[dict[str, str]]:
+              out: list[dict[str, str]] = []
+              seen: set[tuple[str, str]] = set()
+              for b in blockers:
+                  code = str(b.get("code", "")).strip()
+                  msg = str(b.get("message", "")).strip()
+                  sig = (code, msg)
+                  if sig in seen:
+                      continue
+                  seen.add(sig)
+                  out.append({"code": code, "message": msg})
+              return out
+
+          def parse_handles(path: Path) -> dict[str, str]:
+              rx = re.compile(r"^\*\s+`([A-Z0-9_]+)\s*=\s*(.+)`\s*$")
+              out: dict[str, str] = {}
+              for line in path.read_text(encoding="utf-8").splitlines():
+                  m = rx.match(line.strip())
+                  if not m:
+                      continue
+                  key = m.group(1).strip()
+                  raw = m.group(2).strip()
+                  if (raw.startswith('"') and raw.endswith('"')) or (raw.startswith("'") and raw.endswith("'")):
+                      out[key] = raw[1:-1]
+                  else:
+                      out[key] = raw
+              return out
+
+          exec_id = os.environ["EXEC_ID"].strip()
+          run_dir = Path(os.environ["RUN_DIR"].strip())
+          bucket = os.environ["EVIDENCE_BUCKET"].strip()
+          region = os.environ.get("AWS_REGION", "eu-west-2").strip() or "eu-west-2"
+          upstream_m11j = os.environ["UPSTREAM_M11J_EXEC"].strip()
+
+          s3 = boto3.client("s3", region_name=region)
+          blockers: list[dict[str, str]] = []
+          read_errors: list[dict[str, str]] = []
+          upload_errors: list[dict[str, str]] = []
+
+          upstream_key = f"evidence/dev_full/run_control/{upstream_m11j}/m11j_execution_summary.json"
+          upstream_summary: dict[str, Any] = {}
+          try:
+              upstream_summary = s3_get_json(s3, bucket, upstream_key)
+          except (BotoCoreError, ClientError, ValueError, json.JSONDecodeError) as exc:
+              read_errors.append({"surface": upstream_key, "error": type(exc).__name__})
+              blockers.append({"code": "M12-B1", "message": "Unreadable M11.J upstream summary."})
+
+          platform_run_id = ""
+          scenario_run_id = ""
+          if upstream_summary:
+              platform_run_id = str(upstream_summary.get("platform_run_id", "")).strip()
+              scenario_run_id = str(upstream_summary.get("scenario_run_id", "")).strip()
+              if not bool(upstream_summary.get("overall_pass", False)):
+                  blockers.append({"code": "M12-B1", "message": "M11.J upstream summary overall_pass is false."})
+              try:
+                  blocker_count = int(str(upstream_summary.get("blocker_count", "")).strip())
+              except Exception:
+                  blocker_count = -1
+              if blocker_count != 0:
+                  blockers.append({"code": "M12-B1", "message": "M11.J upstream blocker_count is not zero."})
+              if str(upstream_summary.get("next_gate", "")).strip() != "M12_READY":
+                  blockers.append({"code": "M12-B1", "message": "M11.J upstream next_gate is not M12_READY."})
+              if not platform_run_id or not scenario_run_id:
+                  blockers.append({"code": "M12-B1", "message": "M11.J upstream run scope is incomplete."})
+
+          required_handles = [
+              "MPR_PROMOTION_RECEIPT_PATH_PATTERN",
+              "MPR_ROLLBACK_DRILL_PATH_PATTERN",
+              "FP_BUS_LEARNING_REGISTRY_EVENTS_V1",
+              "GOV_APPEND_LOG_PATH_PATTERN",
+              "GOV_RUN_CLOSE_MARKER_PATH_PATTERN",
+              "MF_CANDIDATE_BUNDLE_PATH_PATTERN",
+              "PHASE_BUDGET_ENVELOPE_PATH_PATTERN",
+              "PHASE_COST_OUTCOME_RECEIPT_PATH_PATTERN",
+          ]
+          handles_path = Path("docs/model_spec/platform/migration_to_dev/dev_full_handles.registry.v0.md")
+          handles: dict[str, str] = {}
+          try:
+              handles = parse_handles(handles_path)
+          except Exception as exc:
+              blockers.append({"code": "M12-B1", "message": f"Unable to parse handles registry: {type(exc).__name__}."})
+
+          resolved_handles: dict[str, str] = {}
+          unresolved: list[str] = []
+          for key in required_handles:
+              value = str(handles.get(key, "")).strip()
+              resolved_handles[key] = value
+              if (not value) or (value.upper() == "TO_PIN"):
+                  unresolved.append(key)
+          if unresolved:
+              blockers.append({"code": "M12-B1", "message": f"Unresolved required handles: {', '.join(unresolved)}."})
+
+          handle_snapshot = {
+              "captured_at_utc": now(),
+              "phase": "M12.A",
+              "execution_id": exec_id,
+              "platform_run_id": platform_run_id,
+              "scenario_run_id": scenario_run_id,
+              "upstream_m11j_execution": upstream_m11j,
+              "upstream_summary_key": upstream_key,
+              "required_handles": required_handles,
+              "resolved_handles": resolved_handles,
+              "unresolved_handles": unresolved,
+              "handle_matrix_complete": len(unresolved) == 0,
+          }
+
+          blocker_register = {
+              "captured_at_utc": now(),
+              "phase": "M12.A",
+              "phase_id": "P15",
+              "execution_id": exec_id,
+              "blocker_count": 0,
+              "blockers": [],
+              "overall_pass": False,
+          }
+
+          execution_summary = {
+              "captured_at_utc": now(),
+              "phase": "M12.A",
+              "phase_id": "P15",
+              "execution_id": exec_id,
+              "platform_run_id": platform_run_id,
+              "scenario_run_id": scenario_run_id,
+              "overall_pass": False,
+              "blocker_count": 0,
+              "verdict": "HOLD_REMEDIATE",
+              "next_gate": "HOLD_REMEDIATE",
+              "upstream_refs": {"m11j_execution_id": upstream_m11j},
+              "artifact_keys": {},
+          }
+
+          artifacts = {
+              "m12a_handle_closure_snapshot.json": handle_snapshot,
+              "m12a_blocker_register.json": blocker_register,
+              "m12a_execution_summary.json": execution_summary,
+          }
+
+          run_dir.mkdir(parents=True, exist_ok=True)
+          for fname, payload in artifacts.items():
+              (run_dir / fname).write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+          run_control_prefix = f"evidence/dev_full/run_control/{exec_id}/"
+          for fname, payload in artifacts.items():
+              try:
+                  s3_put_json(s3, bucket, run_control_prefix + fname, payload)
+              except (BotoCoreError, ClientError) as exc:
+                  upload_errors.append({"surface": run_control_prefix + fname, "error": type(exc).__name__})
+                  blockers.append({"code": "M12-B1", "message": f"Failed to publish {fname}."})
+
+          blockers = dedupe(blockers)
+          overall_pass = len(blockers) == 0
+          verdict = "ADVANCE_TO_M12_B" if overall_pass else "HOLD_REMEDIATE"
+          next_gate = "M12.B_READY" if overall_pass else "HOLD_REMEDIATE"
+          blocker_register["blocker_count"] = len(blockers)
+          blocker_register["blockers"] = blockers
+          blocker_register["overall_pass"] = overall_pass
+          execution_summary["overall_pass"] = overall_pass
+          execution_summary["blocker_count"] = len(blockers)
+          execution_summary["verdict"] = verdict
+          execution_summary["next_gate"] = next_gate
+          execution_summary["artifact_keys"] = {
+              "m12a_handle_closure_snapshot": run_control_prefix + "m12a_handle_closure_snapshot.json",
+              "m12a_blocker_register": run_control_prefix + "m12a_blocker_register.json",
+              "m12a_execution_summary": run_control_prefix + "m12a_execution_summary.json",
+          }
+          execution_summary["read_errors"] = read_errors
+          execution_summary["upload_errors"] = upload_errors
+
+          for fname, payload in {
+              "m12a_blocker_register.json": blocker_register,
+              "m12a_execution_summary.json": execution_summary,
+          }.items():
+              (run_dir / fname).write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+              try:
+                  s3_put_json(s3, bucket, run_control_prefix + fname, payload)
+              except Exception:
+                  pass
+
+          print(
+              json.dumps(
+                  {
+                      "execution_id": exec_id,
                       "overall_pass": overall_pass,
                       "blocker_count": len(blockers),
                       "next_gate": next_gate,


### PR DESCRIPTION
## Summary
- update \.github/workflows/dev_full_m12_managed.yml
- add execution_mode=\m12a_execute\
- add managed M12.A handle-closure lane with fail-closed M12-B1 checks

## Why
- execute M12.A on managed lane after M12-B0 closure

## Scope
- workflow file only
