### PR TITLE
chore(workflows): disable dev_min workflows and add dev_full idle teardown guard

### DIFF
--- a/.github/workflows/dev_full_idle_teardown_guard.yml
+++ b/.github/workflows/dev_full_idle_teardown_guard.yml
@@ -1,4 +1,4 @@
-name: dev-min-idle-teardown-guard
+name: dev-full-idle-teardown-guard
 
 on:
   workflow_dispatch:
@@ -15,17 +15,17 @@ on:
       ecs_cluster_name:
         description: "ECS cluster name"
         required: true
-        default: "fraud-platform-dev-min"
+        default: "fraud-platform-dev-full"
         type: string
-      service_name_prefix:
-        description: "Service name prefix"
+      service_name_prefixes:
+        description: "Comma-separated ECS service name prefixes to guard"
         required: true
-        default: "fraud-platform-dev-min"
+        default: "fraud-platform-dev-full"
         type: string
       heartbeat_param_path:
         description: "SSM heartbeat parameter path"
         required: true
-        default: "/fraud-platform/dev_min/demo/manual/heartbeat"
+        default: "/fraud-platform/dev_full/demo/manual/heartbeat"
         type: string
       idle_ttl_minutes:
         description: "Idle threshold in minutes"
@@ -35,61 +35,55 @@ on:
       enforcement_mode:
         description: "Idle-breach enforcement mode"
         required: true
-        default: "stop_services"
+        default: "observe_only"
         type: choice
         options:
           - observe_only
           - stop_services
-          - destroy_demo_stack
-      destroy_workflow_file:
-        description: "Workflow file used when enforcement_mode=destroy_demo_stack"
+          - dispatch_m13_teardown
+      m13_workflow_file:
+        description: "Workflow file used when enforcement_mode=dispatch_m13_teardown"
         required: true
-        default: "dev_min_confluent_destroy.yml"
+        default: "dev_full_m13_managed.yml"
         type: string
-      destroy_workflow_ref:
-        description: "Git ref for destroy workflow dispatch (empty = current ref)"
+      m13_workflow_ref:
+        description: "Git ref for M13 workflow dispatch (empty = current ref)"
         required: false
         default: ""
         type: string
-      required_platform_run_id:
-        description: "Explicit run id for demo destroy dispatch (optional; falls back to heartbeat payload)"
+      m13_upstream_m12j_execution:
+        description: "Upstream M12.J execution id for M13 dispatch mode"
         required: false
         default: ""
         type: string
-      tf_state_bucket:
-        description: "Terraform backend bucket used by destroy workflow"
-        required: true
-        default: "fraud-platform-dev-min-tfstate"
+      m13_upstream_m13e_execution:
+        description: "Upstream M13.E execution id for M13 dispatch mode"
+        required: false
+        default: ""
         type: string
-      tf_lock_table:
-        description: "Terraform lock table used by destroy workflow"
+      m13_teardown_override:
+        description: "Teardown action override for M13.F dispatch mode"
         required: true
-        default: "fraud-platform-dev-min-tf-locks"
-        type: string
-      tf_state_key_demo:
-        description: "Terraform demo stack state key used by destroy workflow"
+        default: "scale_to_zero_or_destroy"
+        type: choice
+        options:
+          - inherit_from_handles
+          - scale_to_zero_or_destroy
+          - scale_to_zero_then_destroy_idle_window
+      m13_evidence_bucket:
+        description: "Evidence bucket input used when dispatching M13 workflow"
         required: true
-        default: "dev_min/demo/terraform.tfstate"
-        type: string
-      destroy_evidence_bucket:
-        description: "Evidence bucket input for destroy workflow dispatch"
-        required: true
-        default: "fraud-platform-dev-min-evidence"
-        type: string
-      destroy_evidence_prefix:
-        description: "Evidence prefix input for destroy workflow dispatch"
-        required: true
-        default: "evidence/dev_min/substrate"
+        default: "fraud-platform-dev-full-evidence"
         type: string
       evidence_bucket:
         description: "Durable evidence bucket for idle guard snapshots"
         required: true
-        default: "fraud-platform-dev-min-evidence"
+        default: "fraud-platform-dev-full-evidence"
         type: string
       evidence_prefix:
         description: "Evidence key prefix for idle guard snapshots"
         required: true
-        default: "evidence/dev_min/run_control"
+        default: "evidence/dev_full/run_control"
         type: string
       upload_evidence_to_s3:
         description: "Upload idle guard snapshot JSON to S3"
@@ -105,32 +99,29 @@ permissions:
   id-token: write
 
 concurrency:
-  group: dev-min-idle-teardown-guard-${{ github.ref_name }}
+  group: dev-full-idle-teardown-guard-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   enforce_idle_guard:
-    name: Enforce dev_min idle guard
-    if: ${{ false }}
+    name: Enforce dev_full idle guard
     runs-on: ubuntu-latest
     env:
-      RESOLVED_AWS_REGION: ${{ inputs.aws_region || vars.DEV_MIN_AWS_REGION || 'eu-west-2' }}
-      RESOLVED_AWS_ROLE: ${{ inputs.aws_role_to_assume || vars.DEV_MIN_AWS_ROLE_TO_ASSUME }}
-      RESOLVED_ECS_CLUSTER: ${{ inputs.ecs_cluster_name || vars.DEV_MIN_ECS_CLUSTER_NAME || 'fraud-platform-dev-min' }}
-      RESOLVED_SERVICE_PREFIX: ${{ inputs.service_name_prefix || vars.DEV_MIN_SERVICE_NAME_PREFIX || 'fraud-platform-dev-min' }}
-      RESOLVED_HEARTBEAT_PARAM: ${{ inputs.heartbeat_param_path || vars.DEV_MIN_HEARTBEAT_PARAM_PATH || '/fraud-platform/dev_min/demo/manual/heartbeat' }}
-      RESOLVED_IDLE_TTL_MINUTES: ${{ inputs.idle_ttl_minutes || vars.DEV_MIN_IDLE_TTL_MINUTES || '90' }}
-      RESOLVED_ENFORCEMENT_MODE: ${{ inputs.enforcement_mode || vars.DEV_MIN_IDLE_GUARD_MODE || 'stop_services' }}
-      RESOLVED_DESTROY_WORKFLOW_FILE: ${{ inputs.destroy_workflow_file || vars.DEV_MIN_DESTROY_WORKFLOW_FILE || 'dev_min_confluent_destroy.yml' }}
-      RESOLVED_DESTROY_WORKFLOW_REF: ${{ inputs.destroy_workflow_ref || vars.DEV_MIN_DESTROY_WORKFLOW_REF || github.ref_name }}
-      RESOLVED_REQUIRED_PLATFORM_RUN_ID: ${{ inputs.required_platform_run_id || vars.DEV_MIN_REQUIRED_PLATFORM_RUN_ID || '' }}
-      RESOLVED_TF_STATE_BUCKET: ${{ inputs.tf_state_bucket || vars.DEV_MIN_TF_STATE_BUCKET || 'fraud-platform-dev-min-tfstate' }}
-      RESOLVED_TF_LOCK_TABLE: ${{ inputs.tf_lock_table || vars.DEV_MIN_TF_LOCK_TABLE || 'fraud-platform-dev-min-tf-locks' }}
-      RESOLVED_TF_STATE_KEY_DEMO: ${{ inputs.tf_state_key_demo || vars.DEV_MIN_TF_STATE_KEY_DEMO || 'dev_min/demo/terraform.tfstate' }}
-      RESOLVED_DESTROY_EVIDENCE_BUCKET: ${{ inputs.destroy_evidence_bucket || vars.DEV_MIN_DESTROY_EVIDENCE_BUCKET || 'fraud-platform-dev-min-evidence' }}
-      RESOLVED_DESTROY_EVIDENCE_PREFIX: ${{ inputs.destroy_evidence_prefix || vars.DEV_MIN_DESTROY_EVIDENCE_PREFIX || 'evidence/dev_min/substrate' }}
-      RESOLVED_EVIDENCE_BUCKET: ${{ inputs.evidence_bucket || vars.DEV_MIN_EVIDENCE_BUCKET || 'fraud-platform-dev-min-evidence' }}
-      RESOLVED_EVIDENCE_PREFIX: ${{ inputs.evidence_prefix || vars.DEV_MIN_EVIDENCE_PREFIX || 'evidence/dev_min/run_control' }}
+      RESOLVED_AWS_REGION: ${{ inputs.aws_region || vars.DEV_FULL_AWS_REGION || 'eu-west-2' }}
+      RESOLVED_AWS_ROLE: ${{ inputs.aws_role_to_assume || vars.DEV_FULL_AWS_ROLE_TO_ASSUME }}
+      RESOLVED_ECS_CLUSTER: ${{ inputs.ecs_cluster_name || vars.DEV_FULL_ECS_CLUSTER_NAME || 'fraud-platform-dev-full' }}
+      RESOLVED_SERVICE_PREFIXES: ${{ inputs.service_name_prefixes || vars.DEV_FULL_SERVICE_NAME_PREFIXES || 'fraud-platform-dev-full' }}
+      RESOLVED_HEARTBEAT_PARAM: ${{ inputs.heartbeat_param_path || vars.DEV_FULL_HEARTBEAT_PARAM_PATH || '/fraud-platform/dev_full/demo/manual/heartbeat' }}
+      RESOLVED_IDLE_TTL_MINUTES: ${{ inputs.idle_ttl_minutes || vars.DEV_FULL_IDLE_TTL_MINUTES || '90' }}
+      RESOLVED_ENFORCEMENT_MODE: ${{ inputs.enforcement_mode || vars.DEV_FULL_IDLE_GUARD_MODE || 'observe_only' }}
+      RESOLVED_M13_WORKFLOW_FILE: ${{ inputs.m13_workflow_file || vars.DEV_FULL_IDLE_M13_WORKFLOW_FILE || 'dev_full_m13_managed.yml' }}
+      RESOLVED_M13_WORKFLOW_REF: ${{ inputs.m13_workflow_ref || vars.DEV_FULL_IDLE_M13_WORKFLOW_REF || github.ref_name }}
+      RESOLVED_M13_UPSTREAM_M12J_EXECUTION: ${{ inputs.m13_upstream_m12j_execution || vars.DEV_FULL_M13_UPSTREAM_M12J_EXECUTION || '' }}
+      RESOLVED_M13_UPSTREAM_M13E_EXECUTION: ${{ inputs.m13_upstream_m13e_execution || vars.DEV_FULL_M13_UPSTREAM_M13E_EXECUTION || '' }}
+      RESOLVED_M13_TEARDOWN_OVERRIDE: ${{ inputs.m13_teardown_override || vars.DEV_FULL_M13_TEARDOWN_OVERRIDE || 'scale_to_zero_or_destroy' }}
+      RESOLVED_M13_EVIDENCE_BUCKET: ${{ inputs.m13_evidence_bucket || vars.DEV_FULL_M13_EVIDENCE_BUCKET || 'fraud-platform-dev-full-evidence' }}
+      RESOLVED_EVIDENCE_BUCKET: ${{ inputs.evidence_bucket || vars.DEV_FULL_EVIDENCE_BUCKET || 'fraud-platform-dev-full-evidence' }}
+      RESOLVED_EVIDENCE_PREFIX: ${{ inputs.evidence_prefix || vars.DEV_FULL_EVIDENCE_PREFIX || 'evidence/dev_full/run_control' }}
       RESOLVED_UPLOAD_EVIDENCE: ${{ (github.event_name == 'schedule') || inputs.upload_evidence_to_s3 }}
     steps:
       - name: Checkout
@@ -150,7 +141,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${RESOLVED_AWS_ROLE}" ]]; then
-            echo "RESOLVED_AWS_ROLE is empty. Set workflow input or repo variable DEV_MIN_AWS_ROLE_TO_ASSUME."
+            echo "RESOLVED_AWS_ROLE is empty. Set workflow input or repo variable DEV_FULL_AWS_ROLE_TO_ASSUME."
             exit 1
           fi
 
@@ -172,9 +163,9 @@ jobs:
           set -euo pipefail
           TS="$(date -u +'%Y%m%dT%H%M%SZ')"
           EXECUTION_ID="idle_guard_${TS}"
-          OUTPUT_DIR="runs/dev_substrate/m9/${TS}"
-          OUTPUT_PATH="${OUTPUT_DIR}/idle_teardown_guard_snapshot.json"
-          S3_URI="s3://${RESOLVED_EVIDENCE_BUCKET}/${RESOLVED_EVIDENCE_PREFIX}/${EXECUTION_ID}/idle_teardown_guard_snapshot.json"
+          OUTPUT_DIR="runs/dev_substrate/dev_full/idle_guard/${TS}"
+          OUTPUT_PATH="${OUTPUT_DIR}/dev_full_idle_teardown_guard_snapshot.json"
+          S3_URI="s3://${RESOLVED_EVIDENCE_BUCKET}/${RESOLVED_EVIDENCE_PREFIX}/${EXECUTION_ID}/dev_full_idle_teardown_guard_snapshot.json"
           mkdir -p "${OUTPUT_DIR}"
           echo "timestamp=${TS}" >> "$GITHUB_OUTPUT"
           echo "execution_id=${EXECUTION_ID}" >> "$GITHUB_OUTPUT"
@@ -191,18 +182,16 @@ jobs:
           AWS_REGION: ${{ env.RESOLVED_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ env.RESOLVED_AWS_ROLE }}
           ECS_CLUSTER_NAME: ${{ env.RESOLVED_ECS_CLUSTER }}
-          SERVICE_NAME_PREFIX: ${{ env.RESOLVED_SERVICE_PREFIX }}
+          SERVICE_NAME_PREFIXES: ${{ env.RESOLVED_SERVICE_PREFIXES }}
           HEARTBEAT_PARAM_PATH: ${{ env.RESOLVED_HEARTBEAT_PARAM }}
           IDLE_TTL_MINUTES: ${{ env.RESOLVED_IDLE_TTL_MINUTES }}
           ENFORCEMENT_MODE: ${{ env.RESOLVED_ENFORCEMENT_MODE }}
-          DESTROY_WORKFLOW_FILE: ${{ env.RESOLVED_DESTROY_WORKFLOW_FILE }}
-          DESTROY_WORKFLOW_REF: ${{ env.RESOLVED_DESTROY_WORKFLOW_REF }}
-          REQUIRED_PLATFORM_RUN_ID: ${{ env.RESOLVED_REQUIRED_PLATFORM_RUN_ID }}
-          TF_STATE_BUCKET: ${{ env.RESOLVED_TF_STATE_BUCKET }}
-          TF_LOCK_TABLE: ${{ env.RESOLVED_TF_LOCK_TABLE }}
-          TF_STATE_KEY_DEMO: ${{ env.RESOLVED_TF_STATE_KEY_DEMO }}
-          DESTROY_EVIDENCE_BUCKET: ${{ env.RESOLVED_DESTROY_EVIDENCE_BUCKET }}
-          DESTROY_EVIDENCE_PREFIX: ${{ env.RESOLVED_DESTROY_EVIDENCE_PREFIX }}
+          M13_WORKFLOW_FILE: ${{ env.RESOLVED_M13_WORKFLOW_FILE }}
+          M13_WORKFLOW_REF: ${{ env.RESOLVED_M13_WORKFLOW_REF }}
+          M13_UPSTREAM_M12J_EXECUTION: ${{ env.RESOLVED_M13_UPSTREAM_M12J_EXECUTION }}
+          M13_UPSTREAM_M13E_EXECUTION: ${{ env.RESOLVED_M13_UPSTREAM_M13E_EXECUTION }}
+          M13_TEARDOWN_OVERRIDE: ${{ env.RESOLVED_M13_TEARDOWN_OVERRIDE }}
+          M13_EVIDENCE_BUCKET: ${{ env.RESOLVED_M13_EVIDENCE_BUCKET }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
@@ -232,10 +221,14 @@ jobs:
           blockers = []
           actions = []
           cluster = os.environ["ECS_CLUSTER_NAME"]
-          prefix = os.environ["SERVICE_NAME_PREFIX"]
+          prefixes_raw = os.environ["SERVICE_NAME_PREFIXES"]
           heartbeat_path = os.environ["HEARTBEAT_PARAM_PATH"]
           mode = os.environ["ENFORCEMENT_MODE"]
           ttl_raw = os.environ["IDLE_TTL_MINUTES"]
+
+          prefixes = [p.strip() for p in prefixes_raw.split(",") if p.strip()]
+          if not prefixes:
+            blockers.append("SERVICE_PREFIXES_EMPTY")
 
           try:
             ttl_minutes = int(ttl_raw)
@@ -245,7 +238,12 @@ jobs:
             blockers.append("INVALID_IDLE_TTL")
 
           service_arns = aws_json(["ecs", "list-services", "--cluster", cluster]).get("serviceArns", [])
-          service_names = [arn.rsplit("/", 1)[-1] for arn in service_arns if prefix in arn]
+          service_names = []
+          for arn in service_arns:
+            service_name = arn.rsplit("/", 1)[-1]
+            if any(prefix in service_name for prefix in prefixes):
+              service_names.append(service_name)
+
           services = []
           failures = []
           for i in range(0, len(service_names), 10):
@@ -261,12 +259,14 @@ jobs:
             desired = int(svc.get("desiredCount", 0))
             running = int(svc.get("runningCount", 0))
             if desired > 0 or running > 0:
-              active_services.append({
-                "service_name": svc.get("serviceName"),
-                "service_arn": svc.get("serviceArn"),
-                "desired_count": desired,
-                "running_count": running,
-              })
+              active_services.append(
+                {
+                  "service_name": svc.get("serviceName"),
+                  "service_arn": svc.get("serviceArn"),
+                  "desired_count": desired,
+                  "running_count": running,
+                }
+              )
 
           heartbeat_payload = {}
           heartbeat_error = ""
@@ -297,13 +297,22 @@ jobs:
           else:
             blockers.append("HEARTBEAT_TIME_MISSING")
 
+          active_run_lock = bool(
+            heartbeat_payload.get("run_active")
+            or heartbeat_payload.get("run_in_progress")
+            or heartbeat_payload.get("active_run")
+            or heartbeat_payload.get("teardown_lock")
+          )
+          if active_run_lock and mode in {"stop_services", "dispatch_m13_teardown"}:
+            blockers.append("ACTIVE_RUN_LOCKED")
+
           idle_breach = idle_minutes is not None and ttl_minutes > 0 and idle_minutes >= ttl_minutes
           enforced = {"mode": mode, "triggered": False, "result": "none", "details": []}
 
-          if mode not in {"observe_only", "stop_services", "destroy_demo_stack"}:
+          if mode not in {"observe_only", "stop_services", "dispatch_m13_teardown"}:
             blockers.append("INVALID_ENFORCEMENT_MODE")
 
-          if idle_breach and len(active_services) > 0 and mode in {"stop_services", "destroy_demo_stack"}:
+          if idle_breach and len(active_services) > 0 and mode in {"stop_services", "dispatch_m13_teardown"} and not active_run_lock:
             enforced["triggered"] = True
             if mode == "stop_services":
               for row in active_services:
@@ -328,29 +337,28 @@ jobs:
               if "IDLE_STOP_SERVICE_UPDATE_FAILED" not in blockers:
                 enforced["result"] = "stopped_services"
                 actions.append("stop_services")
-            elif mode == "destroy_demo_stack":
-              run_id = os.environ.get("REQUIRED_PLATFORM_RUN_ID", "").strip() or str(heartbeat_payload.get("platform_run_id", "")).strip()
-              if not run_id:
-                blockers.append("IDLE_DESTROY_RUN_ID_MISSING")
+            elif mode == "dispatch_m13_teardown":
+              upstream_m12j = os.environ.get("M13_UPSTREAM_M12J_EXECUTION", "").strip()
+              upstream_m13e = os.environ.get("M13_UPSTREAM_M13E_EXECUTION", "").strip()
+              if not upstream_m12j or not upstream_m13e:
+                blockers.append("IDLE_M13_UPSTREAM_INPUT_MISSING")
               else:
                 payload = {
-                  "ref": os.environ.get("DESTROY_WORKFLOW_REF", "") or os.environ.get("GITHUB_REF_NAME", ""),
+                  "ref": os.environ.get("M13_WORKFLOW_REF", "") or os.environ.get("GITHUB_REF_NAME", ""),
                   "inputs": {
-                    "stack_target": "demo",
                     "aws_region": os.environ["AWS_REGION"],
                     "aws_role_to_assume": os.environ["AWS_ROLE_TO_ASSUME"],
-                    "tf_state_bucket": os.environ["TF_STATE_BUCKET"],
-                    "tf_lock_table": os.environ["TF_LOCK_TABLE"],
-                    "tf_state_key_demo": os.environ["TF_STATE_KEY_DEMO"],
-                    "required_platform_run_id": run_id,
-                    "evidence_bucket": os.environ["DESTROY_EVIDENCE_BUCKET"],
-                    "evidence_prefix": os.environ["DESTROY_EVIDENCE_PREFIX"],
-                    "upload_evidence_to_s3": "true",
+                    "evidence_bucket": os.environ["M13_EVIDENCE_BUCKET"],
+                    "m13_subphase": "F",
+                    "execution_mode": "teardown_execution_closure",
+                    "upstream_m12j_execution": upstream_m12j,
+                    "upstream_m13e_execution": upstream_m13e,
+                    "teardown_non_essential_override": os.environ.get("M13_TEARDOWN_OVERRIDE", "scale_to_zero_or_destroy"),
                   },
                 }
                 url = (
                   f"{os.environ.get('GITHUB_API_URL', 'https://api.github.com')}"
-                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/actions/workflows/{os.environ['DESTROY_WORKFLOW_FILE']}/dispatches"
+                  f"/repos/{os.environ['GITHUB_REPOSITORY']}/actions/workflows/{os.environ['M13_WORKFLOW_FILE']}/dispatches"
                 )
                 req = urllib.request.Request(
                   url,
@@ -365,11 +373,17 @@ jobs:
                 try:
                   with urllib.request.urlopen(req, timeout=30):
                     pass
-                  enforced["result"] = "destroy_dispatched"
-                  enforced["details"].append({"required_platform_run_id": run_id})
-                  actions.append("dispatch_destroy_demo_stack")
+                  enforced["result"] = "m13_teardown_dispatched"
+                  enforced["details"].append(
+                    {
+                      "workflow_file": os.environ["M13_WORKFLOW_FILE"],
+                      "upstream_m12j_execution": upstream_m12j,
+                      "upstream_m13e_execution": upstream_m13e,
+                    }
+                  )
+                  actions.append("dispatch_m13_teardown_execution")
                 except Exception as exc:
-                  blockers.append("IDLE_DESTROY_DISPATCH_FAILED")
+                  blockers.append("IDLE_M13_DISPATCH_FAILED")
                   enforced["details"].append({"error": str(exc)})
 
           if idle_breach and len(active_services) > 0 and mode == "observe_only":
@@ -381,26 +395,29 @@ jobs:
               chunk = service_names[i : i + 10]
               payload = aws_json(["ecs", "describe-services", "--cluster", cluster, "--services", *chunk])
               for svc in payload.get("services", []):
-                post_service_rows.append({
-                  "service_name": svc.get("serviceName"),
-                  "desired_count": int(svc.get("desiredCount", 0)),
-                  "running_count": int(svc.get("runningCount", 0)),
-                  "pending_count": int(svc.get("pendingCount", 0)),
-                })
+                post_service_rows.append(
+                  {
+                    "service_name": svc.get("serviceName"),
+                    "desired_count": int(svc.get("desiredCount", 0)),
+                    "running_count": int(svc.get("runningCount", 0)),
+                    "pending_count": int(svc.get("pendingCount", 0)),
+                  }
+                )
 
           overall_pass = len(blockers) == 0
           snapshot = {
-            "phase": "M9",
-            "phase_id": "P12",
-            "lane": "M9.G.idle_teardown_guard",
+            "phase": "M13",
+            "phase_id": "P17",
+            "lane": "M13.idle_teardown_guard",
             "execution_id": os.environ["EXECUTION_ID"],
             "captured_at_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "ecs_cluster_name": cluster,
-            "service_name_prefix": prefix,
+            "service_name_prefixes": prefixes,
             "heartbeat_param_path": heartbeat_path,
             "idle_ttl_minutes": ttl_minutes,
             "idle_minutes": idle_minutes,
             "idle_breach": idle_breach,
+            "active_run_lock": active_run_lock,
             "enforcement_mode": mode,
             "active_service_count": len(active_services),
             "active_services": active_services,
@@ -438,7 +455,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: dev-min-idle-teardown-guard-${{ steps.run_meta.outputs.timestamp }}
+          name: dev-full-idle-teardown-guard-${{ steps.run_meta.outputs.timestamp }}
           path: ${{ steps.run_meta.outputs.output_path }}
           if-no-files-found: error
 

--- a/.github/workflows/dev_min_confluent_destroy.yml
+++ b/.github/workflows/dev_min_confluent_destroy.yml
@@ -78,6 +78,7 @@ env:
 jobs:
   destroy_stack:
     name: Destroy dev_min stack (${{ inputs.stack_target }})
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dev_min_ecs_phase_profile.yml
+++ b/.github/workflows/dev_min_ecs_phase_profile.yml
@@ -96,6 +96,7 @@ concurrency:
 jobs:
   apply_profile:
     name: Apply ECS phase-aware service profile
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dev_min_ecs_rightsizing_report.yml
+++ b/.github/workflows/dev_min_ecs_rightsizing_report.yml
@@ -61,6 +61,7 @@ concurrency:
 jobs:
   capture_rightsizing_report:
     name: Capture ECS p95 rightsizing report
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       RESOLVED_AWS_REGION: ${{ inputs.aws_region || vars.DEV_MIN_AWS_REGION || 'eu-west-2' }}

--- a/.github/workflows/dev_min_m1_packaging.yml
+++ b/.github/workflows/dev_min_m1_packaging.yml
@@ -55,6 +55,7 @@ concurrency:
 jobs:
   build_and_push:
     name: Build and push immutable platform image
+    if: ${{ false }}
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.meta.outputs.image_tag }}

--- a/.github/workflows/dev_min_m2f_topic_readiness.yml
+++ b/.github/workflows/dev_min_m2f_topic_readiness.yml
@@ -53,6 +53,7 @@ concurrency:
 jobs:
   run_m2f:
     name: Apply Confluent stack and verify M2.F topic readiness
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dev_min_m9g_confluent_billing.yml
+++ b/.github/workflows/dev_min_m9g_confluent_billing.yml
@@ -58,6 +58,7 @@ env:
 jobs:
   capture_confluent_billing:
     name: Capture Confluent billing snapshot for M9.G
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/dev_min_m9g_cost_guardrail.yml
+++ b/.github/workflows/dev_min_m9g_cost_guardrail.yml
@@ -130,6 +130,7 @@ concurrency:
 jobs:
   m9g_guardrail:
     name: Capture and enforce M9.G cross-platform cost guardrail
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Scope
Workflow-only promotion from `dev` to `main` (commit-scoped change set).

## Included
- Disable all `dev_min` workflow jobs via explicit job guard (`if: ${{ false }}`).
- Add `dev_full_idle_teardown_guard.yml` with scheduled/manual idle guard and optional dispatch to `dev_full_m13_managed.yml` teardown execution mode.

## Notes
- No non-workflow files are part of this promotion intent.
- Direct push to `main` is blocked by repository rules; this PR is the required path.

## Validation
- YAML parse check passed for the new workflow.
- `dev` already contains the promoted commit (`1558c5990`).
