### PR TITLE
Add managed ingress edge materialization workflow

### DIFF
--- a/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
+++ b/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
@@ -1,0 +1,221 @@
+name: dev-full-pr3-ig-edge-materialize
+
+on:
+  workflow_dispatch:
+    inputs:
+      aws_region:
+        description: "AWS region"
+        required: true
+        default: "eu-west-2"
+        type: string
+      aws_role_to_assume:
+        description: "OIDC role ARN used by GitHub Actions"
+        required: true
+        type: string
+      pr3_execution_id:
+        description: "Strict PR3 execution id"
+        required: true
+        default: "pr3_20260306T021900Z"
+        type: string
+      package_bucket:
+        description: "S3 bucket for the Lambda bundle"
+        required: true
+        default: "fraud-platform-dev-full-object-store"
+        type: string
+      evidence_bucket:
+        description: "S3 bucket for remote evidence backup"
+        required: true
+        default: "fraud-platform-dev-full-evidence"
+        type: string
+      ig_api_key_ssm_path:
+        description: "SSM path for the IG API key"
+        required: true
+        default: "/fraud-platform/dev_full/ig/api_key"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: dev-full-pr3-ig-edge-materialize-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  materialize_ig_edge:
+    name: Materialize production ingress edge
+    runs-on: ubuntu-latest
+    env:
+      TF_DIR: infra/terraform/dev_full/runtime
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Reject static AWS credential posture
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${AWS_ACCESS_KEY_ID:-}" || -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "Static AWS credentials are forbidden; use OIDC role assumption."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build deterministic IG Lambda bundle
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUN_DIR}"
+          python scripts/dev_substrate/build_ig_lambda_bundle.py --repo-root . --output "${ZIP_PATH}"
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import base64
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          zip_path = Path(os.environ["ZIP_PATH"]).resolve()
+          run_dir = Path(os.environ["RUN_DIR"]).resolve()
+          package_key = f"artifacts/lambda/ig_handler/git-{os.environ['GITHUB_SHA']}-run-{os.environ['GITHUB_RUN_ID']}.zip"
+          payload = zip_path.read_bytes()
+          sha256_hex = hashlib.sha256(payload).hexdigest()
+          sha256_b64 = base64.b64encode(hashlib.sha256(payload).digest()).decode("ascii")
+          manifest = {
+              "generated_at_utc": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "bundle_path": str(zip_path),
+              "package_key": package_key,
+              "sha256_hex": sha256_hex,
+              "sha256_base64": sha256_b64,
+              "size_bytes": len(payload),
+          }
+          (run_dir / "ig_edge_bundle_manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          print(f"zip_path={zip_path}")
+          print(f"run_dir={run_dir}")
+          print(f"package_key={package_key}")
+          print(f"sha256_hex={sha256_hex}")
+          print(f"sha256_base64={sha256_b64}")
+          PY
+        env:
+          ZIP_PATH: ${{ runner.temp }}/ig-edge-${{ github.sha }}-${{ github.run_id }}.zip
+          RUN_DIR: runs/dev_substrate/dev_full/road_to_prod/run_control/${{ inputs.pr3_execution_id }}/ig_edge_materialize_${{ github.run_id }}
+
+      - name: Upload Lambda bundle to S3
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws s3 cp "${{ steps.bundle.outputs.zip_path }}" "s3://${{ inputs.package_bucket }}/${{ steps.bundle.outputs.package_key }}" --no-progress
+
+      - name: Terraform init and validate
+        shell: bash
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          set -euo pipefail
+          terraform init -input=false
+          terraform validate
+
+      - name: Apply ingress-edge correction (targeted)
+        shell: bash
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          set -euo pipefail
+          terraform apply -input=false -auto-approve \
+            -target=aws_iam_role_policy_attachment.lambda_ig_vpc_access \
+            -target=aws_iam_role_policy.lambda_ig_runtime \
+            -target=aws_security_group.lambda_ig \
+            -target=aws_lambda_function.ig_handler \
+            -var "lambda_ig_package_s3_bucket=${{ inputs.package_bucket }}" \
+            -var "lambda_ig_package_s3_key=${{ steps.bundle.outputs.package_key }}" \
+            -var "lambda_ig_package_sha256_base64=${{ steps.bundle.outputs.sha256_base64 }}"
+
+      - name: Verify live ingress edge posture
+        shell: bash
+        env:
+          RUN_DIR: ${{ steps.bundle.outputs.run_dir }}
+          IG_API_KEY_SSM_PATH: ${{ inputs.ig_api_key_ssm_path }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import urllib.request
+          from pathlib import Path
+
+          run_dir = Path(os.environ["RUN_DIR"])
+          lambda_name = "fraud-platform-dev-full-ig-handler"
+          region = os.environ["AWS_REGION"]
+
+          cfg = json.loads(subprocess.check_output([
+              "aws", "lambda", "get-function-configuration",
+              "--function-name", lambda_name,
+              "--region", region,
+              "--output", "json",
+          ], text=True))
+          api_key = json.loads(subprocess.check_output([
+              "aws", "ssm", "get-parameter",
+              "--name", os.environ["IG_API_KEY_SSM_PATH"],
+              "--with-decryption",
+              "--region", region,
+              "--output", "json",
+          ], text=True))["Parameter"]["Value"]
+          url = "https://ehwznd2uw7.execute-api.eu-west-2.amazonaws.com/v1/ops/health"
+          req = urllib.request.Request(url, headers={"X-IG-Api-Key": api_key}, method="GET")
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              health = json.loads(resp.read().decode("utf-8"))
+              status_code = int(resp.status)
+
+          summary = {
+              "generated_at_utc": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "lambda_name": lambda_name,
+              "handler": cfg.get("Handler"),
+              "memory_size": cfg.get("MemorySize"),
+              "timeout": cfg.get("Timeout"),
+              "reserved_concurrency": cfg.get("ReservedConcurrentExecutions"),
+              "vpc_subnet_count": len((cfg.get("VpcConfig") or {}).get("SubnetIds") or []),
+              "vpc_security_group_count": len((cfg.get("VpcConfig") or {}).get("SecurityGroupIds") or []),
+              "health_status_code": status_code,
+              "health_mode": health.get("mode"),
+              "health_service": health.get("service"),
+              "health_envelope": health.get("envelope"),
+          }
+          (run_dir / "ig_edge_materialization_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+          (run_dir / "ig_edge_health_response.json").write_text(json.dumps(health, indent=2) + "\n", encoding="utf-8")
+          print(json.dumps(summary, indent=2))
+          if summary["handler"] != "fraud_detection.ingestion_gate.aws_lambda_handler.lambda_handler":
+              raise SystemExit("Ingress Lambda handler drift remains.")
+          if summary["vpc_subnet_count"] < 2:
+              raise SystemExit("Ingress Lambda VPC attachment missing.")
+          if summary["health_status_code"] != 200:
+              raise SystemExit("Ingress Lambda health check failed.")
+          if summary["health_mode"] != "apigw_lambda_ddb_kafka":
+              raise SystemExit("Ingress Lambda health mode drift remains.")
+          PY
+
+      - name: Sync ingress evidence to remote store
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws s3 sync "${{ steps.bundle.outputs.run_dir }}/" "s3://${{ inputs.evidence_bucket }}/evidence/dev_full/run_control/${{ inputs.pr3_execution_id }}/ig_edge_materialize/${{ github.run_id }}/" --no-progress || true
+
+      - name: Upload workflow artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr3-ig-edge-materialize-${{ inputs.pr3_execution_id }}
+          path: |
+            ${{ steps.bundle.outputs.run_dir }}/ig_edge_bundle_manifest.json
+            ${{ steps.bundle.outputs.run_dir }}/ig_edge_materialization_summary.json
+            ${{ steps.bundle.outputs.run_dir }}/ig_edge_health_response.json
+          if-no-files-found: warn

--- a/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
+++ b/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
@@ -17,6 +17,11 @@ on:
         required: true
         default: "pr3_20260306T021900Z"
         type: string
+      code_ref:
+        description: "Branch/ref containing the ingress correction code and Terraform surfaces"
+        required: true
+        default: "cert-platform"
+        type: string
       package_bucket:
         description: "S3 bucket for the Lambda bundle"
         required: true
@@ -50,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.code_ref }}
 
       - name: Reject static AWS credential posture
         shell: bash


### PR DESCRIPTION
## Scope
Adds a workflow-only path to materialize the dev_full ingress edge correction from GitHub Actions.

## Why
PR3 end-to-end runtime proof is currently blocked because the live ingress Lambda is still a stub. This workflow lets us build and deploy the corrected ingress edge remotely without pulling the rest of cert-platform into main.

## What changed
- adds .github/workflows/dev_full_pr3_ig_edge_materialize.yml
- builds the IG Lambda bundle remotely
- uploads the bundle to S3
- applies targeted Terraform to the ingress Lambda/IAM/VPC surfaces
- verifies the live health endpoint after deployment

## Boundaries
- workflow-only PR
- no non-workflow code from cert-platform is included
- the workflow is intended to dispatch against cert-platform ref after merge so it executes the full ingress correction code there
