### PR TITLE
Fix PR3 ingress materialization workflow

### DIFF
--- a/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
+++ b/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
@@ -25,7 +25,7 @@ on:
       package_bucket:
         description: "S3 bucket for the Lambda bundle"
         required: true
-        default: "fraud-platform-dev-full-object-store"
+        default: "fraud-platform-dev-full-artifacts"
         type: string
       evidence_bucket:
         description: "S3 bucket for remote evidence backup"
@@ -77,6 +77,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Build deterministic IG Lambda bundle
         id: bundle


### PR DESCRIPTION
## Summary
- install Terraform in the ingress materialization workflow runner
- repin the workflow default Lambda package bucket to the artifacts bucket
- keep the workflow building the active cert-platform code ref for the ingress correction path

## Why
The remote PR3 ingress materialization lane already proved bundle creation and artifact upload. The remaining blocker was workflow runtime completeness: Terraform was not installed in the GitHub runner, so the job could not reach the actual infra deployment boundary.

This PR is workflow-only so the registered workflow on main can execute the production ingress correction against the active cert-platform code ref.

## Validation
- YAML parsed locally
- previous failed workflow runs isolated the missing Terraform bootstrap as the active blocker
