### PR TITLE
Fix PR3 ingress workflow backend init

### DIFF
--- a/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
+++ b/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
@@ -131,7 +131,7 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          terraform init -input=false
+          terraform init -input=false -reconfigure -backend-config=backend.hcl.example
           terraform validate
 
       - name: Apply ingress-edge correction (targeted)


### PR DESCRIPTION
## Summary
- initialize runtime Terraform with the module's backend.hcl.example in the PR3 ingress materialization workflow

## Why
The workflow now reaches Terraform, and the remaining blocker is that the runtime module uses a partial S3 backend contract. The job must supply the backend config rather than calling bare terraform init.

## Validation
- YAML parsed locally
- failed workflow run 22765148635 isolated the missing backend config as the active blocker
