### PR TITLE
Promote PR3 ingress SSM endpoint recovery workflow

### DIFF
--- a/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
+++ b/.github/workflows/dev_full_pr3_ig_edge_materialize.yml
@@ -140,10 +140,12 @@ jobs:
         run: |
           set -euo pipefail
           terraform apply -input=false -auto-approve \
+            -target='aws_vpc_endpoint.runtime_interface["ssm"]' \
             -target=aws_iam_role_policy_attachment.lambda_ig_vpc_access \
             -target=aws_iam_role_policy.lambda_ig_runtime \
             -target=aws_security_group.lambda_ig \
             -target=aws_lambda_function.ig_handler \
+            -var 'runtime_interface_vpc_endpoint_services=["ec2","ecr.api","ecr.dkr","execute-api","logs","ssm","sts"]' \
             -var "lambda_ig_package_s3_bucket=${{ inputs.package_bucket }}" \
             -var "lambda_ig_package_s3_key=${{ steps.bundle.outputs.package_key }}" \
             -var "lambda_ig_package_sha256_base64=${{ steps.bundle.outputs.sha256_base64 }}"


### PR DESCRIPTION
## Summary
- promote the PR3 ingress recovery workflow update that materializes the missing `ssm` VPC endpoint alongside the targeted IG Lambda recovery lane
- keep the promotion commit scoped to workflow automation only so `main` gains the remote recovery capability without pulling ongoing `cert-platform` runtime/code changes
- unblock truthful control-plane green status by fixing the private-network dependency that was stalling the live ingress edge on Parameter Store access

## Why This Is Needed
The platform wiring work is green at the substrate/control-plane level, but the live `API Gateway -> Lambda -> DDB -> Kafka` ingress edge still depends on SSM-backed auth/bootstrap. In the private Lambda posture, `logs` had already been fixed, but `ssm` was still missing from the runtime endpoint lane. That caused `/ops/health` to time out even after the handler import path was corrected. This PR promotes the workflow-only recovery step needed to materialize that endpoint remotely from `main`.

## Scope
- update `.github/workflows/dev_full_pr3_ig_edge_materialize.yml`
  - include target `aws_vpc_endpoint.runtime_interface["ssm"]`
  - pass the runtime endpoint service list with `ssm` included during the targeted recovery apply

## Outcome Expected After Merge
- `main` can execute the remote ingress recovery lane against `cert-platform` code and actually provision the missing `ssm` endpoint
- the live ingress edge should then move past private-network starvation and into real application-level health verification
- this keeps the repo aligned with the current posture: platform wiring is materially green, while data-plane operational proof remains the next body of work

## Validation
- workflow YAML parses cleanly
- remote failure evidence isolated the cause to missing private access to SSM from the IG Lambda VPC
- promotion is intentionally commit-scoped to workflow automation only